### PR TITLE
Implement Facet Fields

### DIFF
--- a/Classes/Connection/Algolia/IndexFactory.php
+++ b/Classes/Connection/Algolia/IndexFactory.php
@@ -21,6 +21,7 @@ namespace Mahu\SearchAlgolia\Connection\Algolia;
  * 02110-1301, USA.
  */
 
+use AlgoliaSearch\Index;
 use Codappix\SearchCore\Configuration\ConfigurationContainerInterface;
 use TYPO3\CMS\Core\SingletonInterface as Singleton;
 
@@ -58,9 +59,19 @@ class IndexFactory implements Singleton
         $indexName = $this->getIndexNameFromConfiguration($documentType);
 
         if ($indexName) {
+            /** @var Index $index */
             $index = $connection->getClient()->initIndex($indexName);
         } else {
+            /** @var Index $index */
             $index = $connection->getClient()->initIndex($documentType);
+        }
+
+        $facetFields = $this->configuration->getIfExists('indexing.' . $documentType . '.facetFields');
+
+        if ($facetFields) {
+            $index->setSettings([
+                'attributesForFaceting' => explode(',', $facetFields)
+            ]);
         }
 
         return $index;

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -53,7 +53,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Mahu']['SearchAlgolia'] = [
     'writerConfiguration' => [
         \TYPO3\CMS\Core\Log\LogLevel::INFO => [
             \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                'logFile' => '/log/algolia.log'
+                'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath(). '/log/algolia.log'
             ]
         ]
     ],


### PR DESCRIPTION
I added a TypoScript Configuration `facetFields` which works just like `contentFields`.

This field is fetched during Index-Generation and defined as `attributesForFaceting` just like mentioned in the corresponding Algolia Documentation:

https://www.algolia.com/doc/api-reference/api-parameters/attributesForFaceting/#examples