### PR TITLE
Add Compatibility for v8 AND v9

### DIFF
--- a/Classes/Bootstrap.php
+++ b/Classes/Bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mahu\SearchAlgolia;
+
+use Mahu\SearchAlgolia\Utility\EnvironmentInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+class Bootstrap
+{
+    /**
+     * @return object|ObjectManager
+     */
+    public static function getObjectManager()
+    {
+        return GeneralUtility::makeInstance(ObjectManager::class);
+    }
+
+    /**
+     * @return EnvironmentInterface
+     */
+    public static function getEnvironment()
+    {
+        return static::getObjectManager()->get(
+            EnvironmentInterface::class
+        );
+    }
+}

--- a/Classes/Bootstrap.php
+++ b/Classes/Bootstrap.php
@@ -2,7 +2,7 @@
 
 namespace Mahu\SearchAlgolia;
 
-use Mahu\SearchAlgolia\Utility\EnvironmentInterface;
+use Mahu\SearchAlgolia\Compatibility\EnvironmentInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 

--- a/Classes/Compatibility/Environment.php
+++ b/Classes/Compatibility/Environment.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mahu\SearchAlgolia\Compatibility;
+
+use Mahu\SearchAlgolia\Utility\EnvironmentInterface;
+
+class Environment extends \TYPO3\CMS\Core\Core\Environment implements EnvironmentInterface
+{
+    public function getVarPath()
+    {
+        return static::getVarPath();
+    }
+}

--- a/Classes/Compatibility/Environment.php
+++ b/Classes/Compatibility/Environment.php
@@ -2,12 +2,10 @@
 
 namespace Mahu\SearchAlgolia\Compatibility;
 
-use Mahu\SearchAlgolia\Utility\EnvironmentInterface;
-
 class Environment extends \TYPO3\CMS\Core\Core\Environment implements EnvironmentInterface
 {
-    public function getVarPath()
+    public function loggingPath()
     {
-        return static::getVarPath();
+        return self::getVarPath() . '/log';
     }
 }

--- a/Classes/Compatibility/EnvironmentInterface.php
+++ b/Classes/Compatibility/EnvironmentInterface.php
@@ -4,5 +4,5 @@ namespace Mahu\SearchAlgolia\Compatibility;
 
 interface EnvironmentInterface
 {
-    public function getVarPath();
+    public function loggingPath();
 }

--- a/Classes/Compatibility/EnvironmentInterface.php
+++ b/Classes/Compatibility/EnvironmentInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mahu\SearchAlgolia\Compatibility;
+
+interface EnvironmentInterface
+{
+    public function getVarPath();
+}

--- a/Classes/Compatibility/ImplementationRegistrationService.php
+++ b/Classes/Compatibility/ImplementationRegistrationService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mahu\SearchAlgolia\Compatibility;
+
+use Mahu\SearchAlgolia\Compatibility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Extbase\Object\Container\Container;
+
+class ImplementationRegistrationService
+{
+    public static function registerImplementations()
+    {
+        /** @var Container $container */
+        $container = GeneralUtility::makeInstance(Container::class);
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000) {
+            $container->registerImplementation(
+                Compatibility\EnvironmentInterface::class,
+                Compatibility\Environment::class
+            );
+        } else if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            $container->registerImplementation(
+                Compatibility\EnvironmentInterface::class,
+                Compatibility\Version87\Environment::class
+            );
+        }
+    }
+}

--- a/Classes/Compatibility/Version87/Environment.php
+++ b/Classes/Compatibility/Version87/Environment.php
@@ -6,8 +6,8 @@ use Mahu\SearchAlgolia\Compatibility\EnvironmentInterface;
 
 class Environment implements EnvironmentInterface
 {
-    public function getVarPath()
+    public function loggingPath()
     {
-        return 'typo3temp';
+        return 'typo3temp/log';
     }
 }

--- a/Classes/Compatibility/Version87/Environment.php
+++ b/Classes/Compatibility/Version87/Environment.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mahu\SearchAlgolia\Compatibility\Version87;
+
+use Mahu\SearchAlgolia\Compatibility\EnvironmentInterface;
+
+class Environment implements EnvironmentInterface
+{
+    public function getVarPath()
+    {
+        return 'typo3temp';
+    }
+}

--- a/Classes/Connection/Algolia/IndexFactory.php
+++ b/Classes/Connection/Algolia/IndexFactory.php
@@ -21,6 +21,7 @@ namespace Mahu\SearchAlgolia\Connection\Algolia;
  * 02110-1301, USA.
  */
 
+use AlgoliaSearch\Index;
 use Codappix\SearchCore\Configuration\ConfigurationContainerInterface;
 use TYPO3\CMS\Core\SingletonInterface as Singleton;
 
@@ -57,10 +58,23 @@ class IndexFactory implements Singleton
     {
         $indexName = $this->getIndexNameFromConfiguration($documentType);
 
+        /** @var $index Index */
+
         if ($indexName) {
             $index = $connection->getClient()->initIndex($indexName);
         } else {
             $index = $connection->getClient()->initIndex($documentType);
+        }
+
+        $indexConfiguration = $this->configuration->get('indexing.' . $documentType);
+
+        if (isset($indexConfiguration['facetFields'])) {
+            $index->setSettings([
+                'attributesForFaceting' => explode(
+                    ',',
+                    $indexConfiguration['facetFields']
+                )
+            ]);
         }
 
         return $index;

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -5,6 +5,7 @@ plugin {
                 algolia {
                     applicationID = {$plugin.tx_searchalgolia.settings.connections.algolia.applicationID}
                     apiKey = {$plugin.tx_searchalgolia.settings.connections.algolia.apiKey}
+                    readOnlyApiKey = {$plugin.tx_searchalgolia.settings.connections.algolia.readOnlyApiKey}
                 }
             }
             debug = 0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "typo3/minimal": "^9",
+        "typo3/cms-core": ">= 8.7.0 < 10.0.0",
         "codappix/search_core": "dev-feature/update-9",
         "algolia/algoliasearch-client-php": "^1.23",
         "symfony/dotenv": "3.4"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,6 +19,7 @@ $EM_CONF[$_EXTKEY] = [
   'constraints' => [
     'depends' => [
       'typo3' => '8.7.0-9.5.99',
+      'search_core' => '*'
     ],
     'conflicts' => [
     ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,6 +23,8 @@ call_user_func(
             }
         }'
         );
+
+        \Mahu\SearchAlgolia\Compatibility\ImplementationRegistrationService::registerImplementations();
     },
     $_EXTKEY
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,6 +17,7 @@ call_user_func(
                         algolia {
                             applicationID = ' . $settings['appId'] .'
                             apiKey = ' . $settings['adminApiKey'] .'
+                            readOnlyApiKey = ' . $settings['readOnlyApiKey'] .'
                         }
                     }
                 }

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -52,7 +52,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Mahu']['SearchAlgolia'] = [
     'writerConfiguration' => [
         \TYPO3\CMS\Core\Log\LogLevel::INFO => [
             \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                'logFile' => 'typo3temp/log/algolia.log'
+                'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath(). '/log/algolia.log'
             ]
         ]
     ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -52,7 +52,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Mahu']['SearchAlgolia'] = [
     'writerConfiguration' => [
         \TYPO3\CMS\Core\Log\LogLevel::INFO => [
             \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath(). '/log/algolia.log'
+                'logFile' => \Mahu\SearchAlgolia\Bootstrap::getEnvironment()->getVarPath(). '/log/algolia.log'
             ]
         ]
     ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -52,7 +52,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Mahu']['SearchAlgolia'] = [
     'writerConfiguration' => [
         \TYPO3\CMS\Core\Log\LogLevel::INFO => [
             \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                'logFile' => \Mahu\SearchAlgolia\Bootstrap::getEnvironment()->getVarPath(). '/log/algolia.log'
+                'logFile' => \Mahu\SearchAlgolia\Bootstrap::getEnvironment()->loggingPath(). '/algolia.log'
             ]
         ]
     ],


### PR DESCRIPTION
By merging this pull request `search_algolia` is both - compatible with TYPO3 version 8 and the new LTS 9.